### PR TITLE
Fix potential overflow in raw value conversion utilities

### DIFF
--- a/cores/fastarduino/utilities.h
+++ b/cores/fastarduino/utilities.h
@@ -141,7 +141,7 @@ namespace utils
 	}
 
 	/**
-	 * Convert the raw @p value, obtained from a electronics device, using
+	 * Convert the raw @p value, obtained from an electronics device, using
 	 * @p precision_bit number of bits (that defines the input range) into a
 	 * physical measure for which @p range defines the complete output range for
 	 * such value, adjusted according to the unit @p prefix that we want in the
@@ -198,9 +198,9 @@ namespace utils
 		// Here we approximate the calculation by using 2^n instead of (2^n - 1) as input range
 		const int8_t prefix_value = int8_t(prefix);
 		if (prefix_value > 0)
-			return int32_t(value) * int32_t(range) / int32_t(power_of_10(int8_t(prefix))) / int32_t(1UL << precision_bits);
+			return (int32_t(value) * int32_t(range) / int32_t(power_of_10(prefix_value))) >> precision_bits;
 		else
-			return int32_t(value) * int32_t(range) * int32_t(power_of_10(int8_t(prefix))) / int32_t(1UL << precision_bits);
+			return (int32_t(value) * int32_t(range) * int32_t(power_of_10(prefix_value))) >> precision_bits;
 	}
 
 	/**
@@ -256,9 +256,10 @@ namespace utils
 	 */
 	constexpr int16_t map_physical_to_raw(int16_t value, UnitPrefix prefix, int16_t range, uint8_t precision_bits)
 	{
+		//FIXME int32 calculation may lead to 32768 which will be converted to -32768 (instead of 32767)
 		// Here we approximate the calculation by using 2^n instead of (2^n - 1) as input range
 		const int8_t prefix_value = int8_t(prefix);
-		if (prefix_value > 0)
+		if (prefix_value >= 0)
 			return int32_t(value) * int32_t(1UL << precision_bits) * int32_t(power_of_10(prefix_value)) / int32_t(range);
 		else
 			return int32_t(value) * int32_t(1UL << precision_bits) / int32_t(power_of_10(prefix_value)) / int32_t(range);

--- a/cores/fastarduino/utilities.h
+++ b/cores/fastarduino/utilities.h
@@ -198,9 +198,9 @@ namespace utils
 		// Here we approximate the calculation by using 2^n instead of (2^n - 1) as input range
 		const int8_t prefix_value = int8_t(prefix);
 		if (prefix_value > 0)
-			return value * range / power_of_10(int8_t(prefix)) / (1UL << precision_bits);
+			return int32_t(value) * int32_t(range) / int32_t(power_of_10(int8_t(prefix))) / int32_t(1UL << precision_bits);
 		else
-			return value * range * power_of_10(int8_t(prefix)) / (1UL << precision_bits);
+			return int32_t(value) * int32_t(range) * int32_t(power_of_10(int8_t(prefix))) / int32_t(1UL << precision_bits);
 	}
 
 	/**
@@ -259,9 +259,9 @@ namespace utils
 		// Here we approximate the calculation by using 2^n instead of (2^n - 1) as input range
 		const int8_t prefix_value = int8_t(prefix);
 		if (prefix_value > 0)
-			return value * (1UL << precision_bits) * power_of_10(prefix_value) / range;
+			return int32_t(value) * int32_t(1UL << precision_bits) * int32_t(power_of_10(prefix_value)) / int32_t(range);
 		else
-			return value * (1UL << precision_bits) / power_of_10(prefix_value) / range;
+			return int32_t(value) * int32_t(1UL << precision_bits) / int32_t(power_of_10(prefix_value)) / int32_t(range);
 	}
 
 	/**

--- a/examples/misc/UtilsCheck/Makefile
+++ b/examples/misc/UtilsCheck/Makefile
@@ -1,0 +1,34 @@
+#   Copyright 2016-2019 Jean-Francois Poilpret
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Specific to FastArduino examples: we use the current directory name as
+# the target name
+# That allows using the same Makefile for all examples
+THISPATH:=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# Set necessary variables for generic makefile
+# Name of target (binary and derivatives)
+TARGET:=$(lastword $(subst /, ,$(THISPATH)))
+# Where to search for source files (.cpp)
+SOURCE_ROOT:=.
+# Where FastArduino project is located (used to find library and includes)
+FASTARDUINO_ROOT=../../..
+# Additional paths containing includes (usually empty)
+ADDITIONAL_INCLUDES:=
+# Additional paths containing libraries other than fastarduino (usually empty)
+ADDITIONAL_LIBS:=
+
+# include generic makefile for apps
+include $(FASTARDUINO_ROOT)/Makefile-app.mk
+

--- a/examples/misc/UtilsCheck/utilscheck.cpp
+++ b/examples/misc/UtilsCheck/utilscheck.cpp
@@ -1,0 +1,147 @@
+//   Copyright 2016-2019 Jean-Francois Poilpret
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+/*
+ * Special check for FastArduino utilities (kind of unit tests).
+ * Wiring:
+ * - Arduino UNO
+ *   - Standard USB to console
+ */
+
+#include <fastarduino/utilities.h>
+#include <fastarduino/uart.h>
+#include <fastarduino/streams.h>
+#include <fastarduino/iomanip.h>
+
+#ifdef ARDUINO_UNO
+static const board::USART USART = board::USART::USART0;
+// Define vectors we need in the example
+REGISTER_UATX_ISR(0)
+#else
+#error "Current target is not yet supported!"
+#endif
+
+// Buffers for UART
+static const uint8_t OUTPUT_BUFFER_SIZE = 64;
+static char output_buffer[OUTPUT_BUFFER_SIZE];
+
+static const uint8_t BUFFER_SIZE = 10;
+
+using namespace streams;
+using namespace utils;
+
+// NOTE: we allow a delta of 1 in accuracy because map_raw_to_physical() loses
+// 1 bit of precision due to approximation in division (for performance optimization)
+void assert(ostream& out, int16_t expected, int16_t actual, uint16_t delta = 1U)
+{
+	out << "    Comparison ";
+	uint16_t diff;
+	if (expected < actual)
+		diff = actual - expected;
+	else
+		diff = expected - actual;
+	if (diff <= delta)
+		out << " OK exp=" << expected << " act=" << actual << endl;
+	else
+		out << " KO exp=" << expected << " act=" << actual << endl;
+}
+
+void assert_map_raw_to_physical(
+	ostream& out, int16_t expected, int16_t input, UnitPrefix prefix, int16_t range, uint8_t precision_bits)
+{
+	int16_t outut = map_raw_to_physical(input, prefix, range, precision_bits);
+	out	<< "map_raw_to_physical(" 
+		<< input << ", " 
+		<< int8_t(prefix) << ", " 
+		<< range << ", " 
+		<< precision_bits << ")" << endl;
+	assert(out, expected, outut);
+}
+
+void assert_map_physical_to_raw(
+	ostream& out, int16_t expected, int16_t input, UnitPrefix prefix, int16_t range, uint8_t precision_bits)
+{
+	int16_t outut = map_physical_to_raw(input, prefix, range, precision_bits);
+	out	<< "map_physical_to_raw(" 
+		<< input << ", " 
+		<< int8_t(prefix) << ", " 
+		<< range << ", " 
+		<< precision_bits << ")" << endl;
+	assert(out, expected, outut);
+}
+
+int main()
+{
+	board::init();
+	// Enable interrupts at startup time
+	sei();
+
+	// Start UART
+	serial::hard::UATX<USART> uart{output_buffer};
+	uart.begin(115200);
+	ostream out = uart.out();
+	out.flags(ios::boolalpha);
+
+	out << "START..." << endl;
+
+	out << "Checks map_raw_to_physical()" << endl;
+	// Checks on identity mapping (output = input)
+	assert_map_raw_to_physical(out, 0, 0, UnitPrefix::NONE, 32767, 15);
+	assert_map_raw_to_physical(out, 1, 1, UnitPrefix::NONE, 32767, 15);
+	assert_map_raw_to_physical(out, -1, -1, UnitPrefix::NONE, 32767, 15);
+	assert_map_raw_to_physical(out, 16384, 16384, UnitPrefix::NONE, 32767, 15);
+	assert_map_raw_to_physical(out, -16384, -16384, UnitPrefix::NONE, 32767, 15);
+	assert_map_raw_to_physical(out, 32767, 32767, UnitPrefix::NONE, 32767, 15);
+	assert_map_raw_to_physical(out, -32767, -32767, UnitPrefix::NONE, 32767, 15);
+	assert_map_raw_to_physical(out, -32768, -32768, UnitPrefix::NONE, 32767, 15);
+
+	// Examples with possible values from MPU6050 gyro
+	// - ranges: 250, 500, 1000 or 2000 (dps)
+	// - 15 bits precision
+	// - conversion to deci-dps
+	assert_map_raw_to_physical(out, 0, 0, UnitPrefix::DECI, 2000, 15);
+	assert_map_raw_to_physical(out, 10000, 16384, UnitPrefix::DECI, 2000, 15);
+	assert_map_raw_to_physical(out, -10000, -16384, UnitPrefix::DECI, 2000, 15);
+	assert_map_raw_to_physical(out, 20000, 32767, UnitPrefix::DECI, 2000, 15);
+	assert_map_raw_to_physical(out, -20000, -32767, UnitPrefix::DECI, 2000, 15);
+	assert_map_raw_to_physical(out, -20000, -32768, UnitPrefix::DECI, 2000, 15);
+
+	// Examples with possible values from MPU6050 accelerometer
+	// - ranges: 250, 500, 1000 or 2000 (dps)
+	// - 15 bits precision
+	// - conversion to deca-dps
+	assert_map_raw_to_physical(out, 0, 0, UnitPrefix::DECA, 2000, 15);
+	assert_map_raw_to_physical(out, 100, 16384, UnitPrefix::DECA, 2000, 15);
+	assert_map_raw_to_physical(out, -100, -16384, UnitPrefix::DECA, 2000, 15);
+	assert_map_raw_to_physical(out, 200, 32767, UnitPrefix::DECA, 2000, 15);
+	assert_map_raw_to_physical(out, -200, -32767, UnitPrefix::DECA, 2000, 15);
+	assert_map_raw_to_physical(out, -200, -32768, UnitPrefix::DECA, 2000, 15);
+
+	out << endl;
+	out << "Checks map_physical_to_raw()" << endl;
+	// Checks on identity mapping (output = input)
+	assert_map_physical_to_raw(out, 0, 0, UnitPrefix::NONE, 32767, 15);
+	assert_map_physical_to_raw(out, 1, 1, UnitPrefix::NONE, 32767, 15);
+	assert_map_physical_to_raw(out, -1, -1, UnitPrefix::NONE, 32767, 15);
+	assert_map_physical_to_raw(out, 16384, 16384, UnitPrefix::NONE, 32767, 15);
+	assert_map_physical_to_raw(out, -16384, -16384, UnitPrefix::NONE, 32767, 15);
+	assert_map_physical_to_raw(out, 32767, 32767, UnitPrefix::NONE, 32767, 15);
+	assert_map_physical_to_raw(out, -32767, -32767, UnitPrefix::NONE, 32767, 15);
+	assert_map_physical_to_raw(out, -32768, -32768, UnitPrefix::NONE, 32767, 15);
+
+	//TODO check also map_physical_to_raw()
+
+	out << "END" << endl;
+	return 0;
+}

--- a/examples/misc/UtilsCheck/utilscheck.cpp
+++ b/examples/misc/UtilsCheck/utilscheck.cpp
@@ -140,7 +140,25 @@ int main()
 	assert_map_physical_to_raw(out, -32767, -32767, UnitPrefix::NONE, 32767, 15);
 	assert_map_physical_to_raw(out, -32768, -32768, UnitPrefix::NONE, 32767, 15);
 
-	//TODO check also map_physical_to_raw()
+	// Examples with possible values from MPU6050 gyro
+	// - ranges: 250, 500, 1000 or 2000 (dps)
+	// - 15 bits precision
+	// - conversion to deci-dps
+	assert_map_physical_to_raw(out, 0, 0, UnitPrefix::DECI, 2000, 15);
+	assert_map_physical_to_raw(out, 16384, 10000, UnitPrefix::DECI, 2000, 15);
+	assert_map_physical_to_raw(out, -16384, -10000, UnitPrefix::DECI, 2000, 15);
+	assert_map_physical_to_raw(out, 32767, 20000, UnitPrefix::DECI, 2000, 15);
+	assert_map_physical_to_raw(out, -32767, -20000, UnitPrefix::DECI, 2000, 15);
+
+	// Examples with possible values from MPU6050 accelerometer
+	// - ranges: 250, 500, 1000 or 2000 (dps)
+	// - 15 bits precision
+	// - conversion to deca-dps
+	assert_map_physical_to_raw(out, 0, 0, UnitPrefix::DECA, 2000, 15);
+	assert_map_physical_to_raw(out, 16384, 100, UnitPrefix::DECA, 2000, 15);
+	assert_map_physical_to_raw(out, -16384, -100, UnitPrefix::DECA, 2000, 15);
+	assert_map_physical_to_raw(out, 32767, 200, UnitPrefix::DECA, 2000, 15);
+	assert_map_physical_to_raw(out, -32767, -200, UnitPrefix::DECA, 2000, 15);
 
 	out << "END" << endl;
 	return 0;


### PR DESCRIPTION
The utility functions for mapping raw/physical values suffer from
integer overflow and issues with conversions between signed and
unsigned values. In order to handle values near the edge of the
input ranges, calculations must be done in a larger type (i.e.
int32_t when the input is int16_t).